### PR TITLE
Allow spaces inside marker even when it has no attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ module.exports = marker;
 /* HTML type. */
 var T_HTML = 'html';
 
+/* Expression for eliminating extra spaces */
+var SPACES = new RegExp(
+  '\\s+'
+);
+
 /* Expression for parsing parameters. */
 var PARAMETERS = new RegExp(
   '\\s+' +
@@ -112,5 +117,5 @@ function parameters(value) {
     return '';
   });
 
-  return rest ? null : attributes;
+  return rest.replace(SPACES, '') ? null : attributes;
 }

--- a/test.js
+++ b/test.js
@@ -64,6 +64,22 @@ test('normalize(value, allowApostrophes)', function (t) {
 
   node = {
     type: 'html',
+    value: '<!-- foo -->'
+  };
+
+  t.deepEqual(
+    marker(node),
+    {
+      name: 'foo',
+      attributes: '',
+      parameters: {},
+      node: node
+    },
+    'marker without attributes ignoring spaces'
+  );
+
+  node = {
+    type: 'html',
     value: '<!--foo bar-->'
   };
 


### PR DESCRIPTION
Currently, this util returns `null` given the following node...


```js
{
  type: 'html',
  value: '<!-- foo -->'
}
```