### PR TITLE
Fix support for empty attributes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ function parseParameters(value) {
     let value = $2 ?? $3 ?? $4
     const number = Number(value)
 
-    if (value === 'true' || typeof value === 'undefined') {
+    if (value === 'true' || value === undefined) {
       value = true
     } else if (value === 'false') {
       value = false

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,7 @@ function parseParameters(value) {
   function replacer(_, $1, $2, $3, $4) {
     /** @type {MarkerParameterValue} */
 
-    let value = $2 ?? $3 ?? $4
+    let value = $2 === undefined ? ($3 === undefined ? $4 : $3) : $2;
     const number = Number(value)
 
     if (value === 'true' || value === undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ function parseParameters(value) {
 
   return value
     .replace(
-      /\s+([-\w]+)(?:=(?:"((?:\\[\s\S]|[^"])+)"|'((?:\\[\s\S]|[^'])+)'|((?:\\[\s\S]|[^"'\s])+)))?/gi,
+      /\s+([-\w]+)(?:=(?:"((?:\\[\s\S]|[^"])*)"|'((?:\\[\s\S]|[^'])*)'|((?:\\[\s\S]|[^"'\s])+)))?/gi,
       replacer
     )
     .replace(/\s+/g, '')
@@ -128,14 +128,15 @@ function parseParameters(value) {
   // eslint-disable-next-line max-params
   function replacer(_, $1, $2, $3, $4) {
     /** @type {MarkerParameterValue} */
-    let value = $2 || $3 || $4 || ''
+
+    let value = $2 ?? $3 ?? $4
     const number = Number(value)
 
-    if (value === 'true' || value === '') {
+    if (value === 'true' || typeof value === 'undefined') {
       value = true
     } else if (value === 'false') {
       value = false
-    } else if (!Number.isNaN(number)) {
+    } else if (value.trim() && !Number.isNaN(number)) {
       value = number
     }
 

--- a/test.js
+++ b/test.js
@@ -164,6 +164,32 @@ test('commentMaker', () => {
     null,
     'marker stop for invalid parameters (#3)'
   )
+
+  html = {type: 'html', value: '<!--foo bar="" -->'}
+
+  assert.deepEqual(
+    commentMarker(html),
+    {
+      name: 'foo',
+      attributes: 'bar=""',
+      parameters: {bar: ''},
+      node: html
+    },
+    'marker with empty string attribute'
+  )
+
+  html = {type: 'html', value: '<!--foo bar="  " -->'}
+
+  assert.deepEqual(
+    commentMarker(html),
+    {
+      name: 'foo',
+      attributes: 'bar="  "',
+      parameters: {bar: '  '},
+      node: html
+    },
+    'marker with whitespace attribute'
+  )
 })
 
 test('comment node', () => {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This change adds handling for attributes that are explicitly set with an empty string `""` or all whitespace `"  "`.

Prior to this, html comments that contained an empty string attribute were ignored completely. 

For example, given the following html `commentMarker` returns `null`.

```js
const html = '<!-- action target="1234" field="type" value="" -->'
const marker = commentMarker(node)
// marker === null
```

Additionally, attributes with whitespace only were coerced to `number` resulting in unexpected behavior.

For example, the following results in an attribute value of `0`.

```js
const html = '<!-- action target="1234" field="type" value=" " -->'
const marker = commentMarker(node)
// marker.parameters === {
//   target: 1234,
//   field: "type",
//   value: 0,
// }
```

<!--do not edit: pr-->
